### PR TITLE
Fix exception in ConsoleRender when property has been removed

### DIFF
--- a/core/src/main/java/com/qdesrame/openapi/diff/core/output/ConsoleRender.java
+++ b/core/src/main/java/com/qdesrame/openapi/diff/core/output/ConsoleRender.java
@@ -213,10 +213,17 @@ public class ConsoleRender implements Render {
       String propPrefix, String title, Map<String, Schema> properties, DiffContext context) {
     StringBuilder sb = new StringBuilder();
     if (properties != null) {
-      properties.forEach(
-          (key, value) -> sb.append(property(propPrefix + key, title, resolve(value))));
+      properties.forEach((key, value) -> sb.append(resolveProperty(propPrefix, value, key, title)));
     }
     return sb.toString();
+  }
+
+  private String resolveProperty(String propPrefix, Schema value, String key, String title) {
+    try {
+      return property(propPrefix + key, title, resolve(value));
+    } catch (Exception e) {
+      return property(propPrefix + key, title, type(value));
+    }
   }
 
   protected String property(String name, String title, Schema schema) {

--- a/core/src/test/java/com/qdesrame/openapi/test/ConsoleRenderTest.java
+++ b/core/src/test/java/com/qdesrame/openapi/test/ConsoleRenderTest.java
@@ -1,0 +1,18 @@
+package com.qdesrame.openapi.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.qdesrame.openapi.diff.core.OpenApiCompare;
+import com.qdesrame.openapi.diff.core.model.ChangedOpenApi;
+import com.qdesrame.openapi.diff.core.output.ConsoleRender;
+import org.junit.jupiter.api.Test;
+
+public class ConsoleRenderTest {
+  @Test
+  public void renderDoesNotFailWhenPropertyHasBeenRemoved() {
+    ConsoleRender render = new ConsoleRender();
+    ChangedOpenApi diff =
+        OpenApiCompare.fromLocations("missing_property_1.yaml", "missing_property_2.yaml");
+    assertThat(render.render(diff)).isNotBlank();
+  }
+}

--- a/core/src/test/resources/missing_property_1.yaml
+++ b/core/src/test/resources/missing_property_1.yaml
@@ -1,0 +1,31 @@
+openapi: 3.0.1
+info:
+  title: Title
+  version: 1.0.0
+  description: Description
+paths:
+  /:
+    get:
+      summary: Simple GET
+      operationId: simpleGet
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Wrapper'
+      description: Simple GET
+components:
+  schemas:
+    Wrapper:
+      type: object
+      properties:
+        id:
+          type: string
+        childProperty:
+          $ref: '#/components/schemas/ChildProperty'
+    ChildProperty:
+      type: object
+      properties:
+        id:
+          type: string

--- a/core/src/test/resources/missing_property_2.yaml
+++ b/core/src/test/resources/missing_property_2.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.1
+info:
+  title: Title
+  version: 1.0.0
+  description: Description
+paths:
+  /:
+    get:
+      summary: Simple GET
+      operationId: simpleGet
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Wrapper'
+      description: Simple GET
+components:
+  schemas:
+    Wrapper:
+      type: object
+      properties:
+        id:
+          type: string


### PR DESCRIPTION
`ConsoleRender` failed to resolve component schemas which had been removed in the "new" OpenAPI specification and threw an `IllegalArgumentException`:

```
Unexpected exception. Reason: ref '#/components/schemas/RemovedSchema' doesn't exist.

java.lang.IllegalArgumentException: ref '#/components/schemas/PermissionSet' doesn't exist.
	at com.qdesrame.openapi.diff.core.utils.RefPointer.resolveRef(RefPointer.java:20)
	at com.qdesrame.openapi.diff.core.output.ConsoleRender.resolve(ConsoleRender.java:231)
	at com.qdesrame.openapi.diff.core.output.ConsoleRender.lambda$properties$1(ConsoleRender.java:217)
	at java.util.LinkedHashMap.forEach(LinkedHashMap.java:684)
	at com.qdesrame.openapi.diff.core.output.ConsoleRender.properties(ConsoleRender.java:216)
	at com.qdesrame.openapi.diff.core.output.ConsoleRender.incompatibilities(ConsoleRender.java:199)
	at com.qdesrame.openapi.diff.core.output.ConsoleRender.lambda$incompatibilities$0(ConsoleRender.java:202)
	at java.util.LinkedHashMap.forEach(LinkedHashMap.java:684)
	at com.qdesrame.openapi.diff.core.output.ConsoleRender.incompatibilities(ConsoleRender.java:202)
	at com.qdesrame.openapi.diff.core.output.ConsoleRender.incompatibilities(ConsoleRender.java:185)
	at com.qdesrame.openapi.diff.core.output.ConsoleRender.itemContent(ConsoleRender.java:179)
	at com.qdesrame.openapi.diff.core.output.ConsoleRender.ul_content(ConsoleRender.java:155)
	at com.qdesrame.openapi.diff.core.output.ConsoleRender.ol_changed(ConsoleRender.java:87)
	at com.qdesrame.openapi.diff.core.output.ConsoleRender.render(ConsoleRender.java:47)
	at com.qdesrame.openapi.diff.cli.Main.main(Main.java:159)
```