### PR TITLE
Fix exceptions in HTML and Markdown renderers with removed property

### DIFF
--- a/core/src/main/java/com/qdesrame/openapi/diff/core/output/HtmlRender.java
+++ b/core/src/main/java/com/qdesrame/openapi/diff/core/output/HtmlRender.java
@@ -269,7 +269,16 @@ public class HtmlRender implements Render {
       Map<String, Schema> properties,
       DiffContext context) {
     if (properties != null) {
-      properties.forEach((key, value) -> property(output, propPrefix + key, title, resolve(value)));
+      properties.forEach((key, value) -> resolveProperty(output, propPrefix, key, value, title));
+    }
+  }
+
+  private void resolveProperty(
+      ContainerTag output, String propPrefix, String key, Schema value, String title) {
+    try {
+      property(output, propPrefix + key, title, resolve(value));
+    } catch (Exception e) {
+      property(output, propPrefix + key, title, type(value));
     }
   }
 

--- a/core/src/main/java/com/qdesrame/openapi/diff/core/output/MarkdownRender.java
+++ b/core/src/main/java/com/qdesrame/openapi/diff/core/output/MarkdownRender.java
@@ -381,13 +381,21 @@ public class MarkdownRender implements Render {
     if (properties != null) {
       properties.forEach(
           (key, value) -> {
-            sb.append(property(deepness, title, key, resolve(value)));
+            sb.append(resolveProperty(deepness, value, key, title));
             if (showContent) {
               sb.append(schema(deepness + 1, resolve(value), context));
             }
           });
     }
     return sb.toString();
+  }
+
+  private String resolveProperty(int deepness, Schema value, String key, String title) {
+    try {
+      return property(deepness, title, key, resolve(value));
+    } catch (Exception e) {
+      return property(deepness, title, key, type(value), "");
+    }
   }
 
   protected String property(int deepness, String name, ChangedSchema schema) {

--- a/core/src/test/java/com/qdesrame/openapi/test/HtmlRenderTest.java
+++ b/core/src/test/java/com/qdesrame/openapi/test/HtmlRenderTest.java
@@ -1,0 +1,18 @@
+package com.qdesrame.openapi.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.qdesrame.openapi.diff.core.OpenApiCompare;
+import com.qdesrame.openapi.diff.core.model.ChangedOpenApi;
+import com.qdesrame.openapi.diff.core.output.HtmlRender;
+import org.junit.jupiter.api.Test;
+
+public class HtmlRenderTest {
+  @Test
+  public void renderDoesNotFailWhenPropertyHasBeenRemoved() {
+    HtmlRender render = new HtmlRender();
+    ChangedOpenApi diff =
+        OpenApiCompare.fromLocations("missing_property_1.yaml", "missing_property_2.yaml");
+    assertThat(render.render(diff)).isNotBlank();
+  }
+}

--- a/core/src/test/java/com/qdesrame/openapi/test/MarkdownRenderTest.java
+++ b/core/src/test/java/com/qdesrame/openapi/test/MarkdownRenderTest.java
@@ -1,0 +1,18 @@
+package com.qdesrame.openapi.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.qdesrame.openapi.diff.core.OpenApiCompare;
+import com.qdesrame.openapi.diff.core.model.ChangedOpenApi;
+import com.qdesrame.openapi.diff.core.output.MarkdownRender;
+import org.junit.jupiter.api.Test;
+
+public class MarkdownRenderTest {
+  @Test
+  public void renderDoesNotFailWhenPropertyHasBeenRemoved() {
+    MarkdownRender render = new MarkdownRender();
+    ChangedOpenApi diff =
+        OpenApiCompare.fromLocations("missing_property_1.yaml", "missing_property_2.yaml");
+    assertThat(render.render(diff)).isNotBlank();
+  }
+}


### PR DESCRIPTION
`HtmlRender` and `MarkdownRender` failed to resolve component schemas which had been removed in the "new" OpenAPI specification and threw an `IllegalArgumentException`.

Refs #7